### PR TITLE
rails credentials in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM ruby:2.7.1-alpine
 
+ENV RAILS_ENV=production \
+    NODE_ENV=production \
+    RAILS_SERVE_STATIC_FILES=true \
+    RAILS_LOG_TO_STDOUT=true
+
 WORKDIR /csc-app
 
 RUN apk add --update build-base postgresql-dev tzdata nodejs yarn

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
### Context
We need to have a production environment running for our docker image
### Changes proposed in this pull request
Add ENVs  to Dockerfile and activate rails credentials for production
### Guidance to review

