### PR TITLE
Foster parent sign in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "foreman"
 gem "puma", "~> 5.0"
 
 # frontend
+gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "webpacker"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,9 @@ GEM
     foreman (0.87.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govuk-components (0.5.0)
+      rails (~> 6.0.3, >= 6.0.3)
+      view_component (~> 2.18.1)
     govuk_design_system_formbuilder (2.1.0)
       actionview (>= 5.2)
       activemodel (>= 5.2)
@@ -306,6 +309,8 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    view_component (2.18.2)
+      activesupport (>= 5.0.0, < 7.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.0.4)
@@ -342,6 +347,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   foreman
+  govuk-components
   govuk_design_system_formbuilder
   listen (>= 3.0.5, < 3.3)
   mail-notify

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,0 @@
-class DashboardController < ApplicationController
-  def show
-    skip_authorization
-  end
-end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,13 @@
 class UsersController < ApplicationController
   skip_after_action :verify_authorized, :verify_policy_scoped
+
+private
+
+  def after_sign_in_path_for(_resource_or_scope)
+    if pundit_user.role_model.is_a?(FosterParent)
+      foster_parent_path(pundit_user.role_model)
+    else
+      super
+    end
+  end
 end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,5 +1,0 @@
-<p>
-  Thank you for signing in, <%= current_user.email %>
-</p>
-
-<%= button_to("Sign out", destroy_user_session_path, method: :delete, class: "govuk-button", data: { module: "govuk-button" }) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,9 +37,11 @@
               <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
                 <%= link_to "Home", root_path, class: "govuk-header__link" %>
               </li>
-              <li class="govuk-header__navigation-item">
-                <%= link_to "Dashboard", dashboard_path, class: "govuk-header__link" %>
-              </li>
+              <% if user_signed_in? %>
+                <li class="govuk-header__navigation-item">
+                <%= link_to("Sign out", destroy_user_session_path, method: :delete, class: "govuk-header__link", data: { module: "govuk-button" }) %>
+                </li>
+              <% end %>
             </ul>
           </nav>
         </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,8 @@
 <p>Welcome to Children Social Care Placement!</p>
-<p>TERRAFORMING IS GO!</p>
+
+<p>If you are part of the Alpha project, please continue.</p>
+
+<%= render GovukComponent::StartNowButton.new(
+    text: 'Start',
+    href: new_user_session_path)
+%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :foster_parents, only: :show
-  resource :dashboard, only: :show, controller: :dashboard
 
   get "/pages/:page", to: "pages#show"
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+notify:
+  view_template_id: "some_template_id"

--- a/spec/features/user_start_spec.rb
+++ b/spec/features/user_start_spec.rb
@@ -50,5 +50,16 @@ RSpec.feature "User can start using the system by signing in and being redirecte
 
       expect(page).to have_content("Welcome to Children Social Care Placement!")
     end
+
+    scenario "User it not signed in, clicks Start but provides incorrect sign in details" do
+      visit "/"
+
+      click_on "Start"
+      fill_in "Email", with: user.email
+      fill_in "Password", with: "wrong password"
+      click_on "Sign in"
+
+      expect(page).to have_content("Invalid Email or password.")
+    end
   end
 end

--- a/spec/features/user_start_spec.rb
+++ b/spec/features/user_start_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.feature "User can start using the system by signing in and being redirected to the right place", type: :feature do
+  context "User is a foster parent" do
+    let(:user) { FactoryBot.create(:user) }
+    let!(:foster_parent) { FactoryBot.create(:foster_parent, user: user) }
+
+    scenario "User is not signed in, clicks Start on the homepage, signs in and is redirected to their dashboard page" do
+      visit "/"
+
+      click_on "Start"
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user.password
+      click_on "Sign in"
+
+      expect(page).to have_content("Children in your care")
+    end
+
+    scenario "User is already signed in, clicks Start on the homepage and is redirected to their dashboard page" do
+      sign_in(user)
+
+      visit "/"
+
+      click_on "Start"
+
+      expect(page).to have_content("Children in your care")
+    end
+  end
+
+  context "User is not a foster parent" do
+    let(:user) { FactoryBot.create(:user) }
+
+    scenario "User is not signed in, clicks Start on the homepage, signs in and is redirected back to the home page" do
+      visit "/"
+
+      click_on "Start"
+      fill_in "Email", with: user.email
+      fill_in "Password", with: user.password
+      click_on "Sign in"
+
+      expect(page).to have_content("Welcome to Children Social Care Placement!")
+    end
+
+    scenario "User is already signed in, clicks Start on the homepage and is redirected back to the homepage" do
+      sign_in(user)
+
+      visit "/"
+
+      click_on "Start"
+
+      expect(page).to have_content("Welcome to Children Social Care Placement!")
+    end
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Devise::Test::IntegrationHelpers, type: :feature
+end


### PR DESCRIPTION
### Context

Few tweaks and cleanups around the foster parent sign in journey.

### Changes proposed in this pull request

* Start button on the homepage redirects to the sign in page, or foster parent page (if already signed in)
* For other than foster parent, the successful sign in redirects back to the homepage
* Dashboard controller removed, replaced with `Sign out` button in the header
* Feature specs to cover this part of the journey

### Guidance to review

Nothing special here, simply trying the journey from the homepage.

