### PR TITLE
Basic shortlisting

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -1,0 +1,23 @@
+class ChildrenController < ApplicationController
+  def new
+    @child = Child.new
+    authorize @child
+  end
+
+  def create
+    @child = Child.new(child_params)
+    authorize @child
+
+    if @child.save
+      redirect_to(shortlist_path(@child.id))
+    else
+      render :new
+    end
+  end
+
+private
+
+  def child_params
+    params.require(:child).permit(:first_name, :last_name)
+  end
+end

--- a/app/controllers/placements_controller.rb
+++ b/app/controllers/placements_controller.rb
@@ -1,0 +1,14 @@
+class PlacementsController < ApplicationController
+  def create
+    @placement = Placement.new(placement_params)
+    authorize @placement
+
+    @placement.save!
+  end
+
+private
+
+  def placement_params
+    params.require(:placement).permit(:foster_parent_id, :child_id)
+  end
+end

--- a/app/controllers/shortlists_controller.rb
+++ b/app/controllers/shortlists_controller.rb
@@ -1,0 +1,12 @@
+class ShortlistsController < ApplicationController
+  def show
+    @child = Child.find(params[:id])
+    @shortlist = Shortlist.new(child: @child)
+    authorize @shortlist
+
+    @placed = @child.placements.present?
+    unless @placed
+      @available_foster_parents = FosterParent.left_outer_joins(:placements).where(placements: { foster_parent_id: nil })
+    end
+  end
+end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,10 +1,6 @@
 class Child < ApplicationRecord
+  include NameIdentifiable
+
   has_many :placements, inverse_of: :child
   has_many :foster_parents, through: :placements
-
-  validates :first_name, :last_name, presence: true
-
-  def full_name
-    [first_name, middle_name, last_name].compact.join(" ")
-  end
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -3,4 +3,8 @@ class Child < ApplicationRecord
   has_many :foster_parents, through: :placements
 
   validates :first_name, :last_name, presence: true
+
+  def full_name
+    [first_name, middle_name, last_name].compact.join(" ")
+  end
 end

--- a/app/models/concerns/name_identifiable.rb
+++ b/app/models/concerns/name_identifiable.rb
@@ -1,0 +1,11 @@
+module NameIdentifiable
+  extend ActiveSupport::Concern
+
+  included do
+    validates :first_name, :last_name, presence: true
+  end
+
+  def full_name
+    [first_name, middle_name, last_name].compact.join(" ")
+  end
+end

--- a/app/models/foster_parent.rb
+++ b/app/models/foster_parent.rb
@@ -4,4 +4,8 @@ class FosterParent < ApplicationRecord
   has_many :children, through: :placements
 
   validates :first_name, :last_name, presence: true
+
+  def full_name
+    [first_name, middle_name, last_name].compact.join(" ")
+  end
 end

--- a/app/models/foster_parent.rb
+++ b/app/models/foster_parent.rb
@@ -1,11 +1,7 @@
 class FosterParent < ApplicationRecord
+  include NameIdentifiable
+
   belongs_to :user, optional: false, inverse_of: :foster_parent
   has_many :placements, inverse_of: :foster_parent
   has_many :children, through: :placements
-
-  validates :first_name, :last_name, presence: true
-
-  def full_name
-    [first_name, middle_name, last_name].compact.join(" ")
-  end
 end

--- a/app/models/matchmaker.rb
+++ b/app/models/matchmaker.rb
@@ -1,5 +1,5 @@
 class Matchmaker < ApplicationRecord
-  belongs_to :user, optional: false, inverse_of: :matchmaker
+  include NameIdentifiable
 
-  validates :first_name, :last_name, presence: true
+  belongs_to :user, optional: false, inverse_of: :matchmaker
 end

--- a/app/models/shortlist.rb
+++ b/app/models/shortlist.rb
@@ -1,0 +1,9 @@
+class Shortlist
+  attr_reader :id
+  attr_reader :child
+
+  def initialize(child:)
+    @child = child
+    @id = child.id
+  end
+end

--- a/app/models/shortlist.rb
+++ b/app/models/shortlist.rb
@@ -1,6 +1,5 @@
 class Shortlist
-  attr_reader :id
-  attr_reader :child
+  attr_reader :id, :child
 
   def initialize(child:)
     @child = child

--- a/app/policies/child_policy.rb
+++ b/app/policies/child_policy.rb
@@ -1,0 +1,9 @@
+class ChildPolicy < ApplicationPolicy
+  def new?
+    create?
+  end
+
+  def create?
+    @auth_context.role_model.is_a?(Matchmaker)
+  end
+end

--- a/app/policies/placement_policy.rb
+++ b/app/policies/placement_policy.rb
@@ -1,0 +1,5 @@
+class PlacementPolicy < ApplicationPolicy
+  def create?
+    @auth_context.role_model.is_a?(Matchmaker)
+  end
+end

--- a/app/policies/shortlist_policy.rb
+++ b/app/policies/shortlist_policy.rb
@@ -1,0 +1,5 @@
+class ShortlistPolicy < ApplicationPolicy
+  def show?
+    @auth_context.role_model.is_a?(Matchmaker)
+  end
+end

--- a/app/views/children/new.html.erb
+++ b/app/views/children/new.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Enter a child's details</h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= form_for(@child) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :first_name %>
+      <%= f.govuk_text_field :last_name %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+
+  </div>
+</div>
+
+

--- a/app/views/children/new.html.erb
+++ b/app/views/children/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:back_button) do %>
+    <%= render GovukComponent::BackLink.new(text: 'Dashboard',href: dashboards_matchmaker_path) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Enter a child's details</h1>

--- a/app/views/dashboards/matchmaker.html.erb
+++ b/app/views/dashboards/matchmaker.html.erb
@@ -3,3 +3,13 @@
     <h1 class="govuk-heading-xl">Search and shortlist foster families</h1>
   </div>
 </div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render GovukComponent::StartNowButton.new(
+      text: 'Place a child',
+      href: new_child_path)
+    %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,8 @@
         </p>
       </div>
 
+      <%= yield :back_button %>
+
       <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
         <%= render("layouts/flash_messages") %>
 

--- a/app/views/placements/create.html.erb
+++ b/app/views/placements/create.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:back_button) do %>
+  <%= render GovukComponent::BackLink.new(text: 'Dashboard',href: dashboards_matchmaker_path) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">Placement created</h1>

--- a/app/views/placements/create.html.erb
+++ b/app/views/placements/create.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Placement created</h1>
+    <h2 class="govuk-heading-m">For <%= @placement.child.full_name %></h2>
+  </div>
+</div>

--- a/app/views/shortlists/show.html.erb
+++ b/app/views/shortlists/show.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Foster families</h1>
+    <h2 class="govuk-heading-m">For <%= @child.full_name %></h2>
+  </div>
+</div>
+
+<% if @placed %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <p><%= @child.full_name %> is currently placed.</p>
+    </div>
+  </div>
+<% elsif @available_foster_parents.empty? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <p>There are currently no available foster families.</p>
+    </div>
+  </div>
+<% else %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <p><%= @available_foster_parents.count %> available families found:</p>
+    </div>
+  </div>
+
+  <% @available_foster_parents.each do |foster_parent| %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full" id="foster_parent_<%= foster_parent.id %>">
+        <h2 class="govuk-heading-m"><%= foster_parent.full_name %></h2>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/shortlists/show.html.erb
+++ b/app/views/shortlists/show.html.erb
@@ -28,6 +28,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full" id="foster_parent_<%= foster_parent.id %>">
         <h2 class="govuk-heading-m"><%= foster_parent.full_name %></h2>
+        <%= govuk_button_to("Place", placements_path, params: { placement: { foster_parent_id: foster_parent.id, child_id: @child.id } }) %>
       </div>
     </div>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,9 +37,9 @@ en:
         user:
           attributes:
             email:
-              blank: Please provide a valid email address
+              blank: "Please provide a valid email address"
             password:
-              blank: Please provide a password
+              blank: "Please provide a password"
   select_events:
     event_options:
       home_life: home life
@@ -58,3 +58,16 @@ en:
           attributes:
             entry:
               too_short: "An entry must have at least %{count} characters"
+
+  errors:
+    attributes:
+      first_name:
+        blank: "Enter the first name"
+      last_name:
+        blank: "Enter the last name"
+
+  helpers:
+    label:
+      child:
+        first_name: "First name"
+        last_name: "Last name"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   get "/dashboards/foster_parent", to: "dashboards#foster_parent"
   get "/dashboards/matchmaker", to: "dashboards#matchmaker"
 
+  resources :shortlists, only: :show
+
   get "/pages/:page", to: "pages#show"
 
   get "/404", to: "errors#not_found", via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get "/dashboards/matchmaker", to: "dashboards#matchmaker"
 
   resources :shortlists, only: :show
+  resources :placements, only: :create
 
   get "/pages/:page", to: "pages#show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   resources :shortlists, only: :show
   resources :placements, only: :create
+  resources :children, only: %i[new create]
 
   get "/pages/:page", to: "pages#show"
 

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :child do
+    first_name { "Rosie" }
+    last_name { "Child" }
+  end
+end

--- a/spec/factories/placements.rb
+++ b/spec/factories/placements.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :placement do
+    foster_parent
+    child
+  end
+end

--- a/spec/features/short_listing/create_a_child_spec.rb
+++ b/spec/features/short_listing/create_a_child_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.feature "Matchmaker creates a new Child", type: :feature do
+  let(:matchmaker) { create(:matchmaker) }
+
+  let(:child_attributes) { attributes_for(:child) }
+  let(:created_child) { Child.last }
+
+  background do
+    sign_in(matchmaker.user)
+
+    visit(new_child_path)
+  end
+
+  scenario "Matchmaker fills in the Child's details correctly, confirms creation and lands on the shortlist page" do
+    fill_in "First name", with: child_attributes[:first_name]
+    fill_in "Last name", with: child_attributes[:last_name]
+    click_on "Continue"
+
+    expect(page).to have_content("Foster families")
+    expect(page).to have_content("For #{created_child.full_name}")
+  end
+
+  scenario "Matchmaker makes an error while providing the Child's details and stays on the form with errors" do
+    fill_in "Last name", with: child_attributes[:last_name]
+    click_on "Continue"
+
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Enter the first name")
+  end
+end

--- a/spec/features/short_listing/place_a_child_spec.rb
+++ b/spec/features/short_listing/place_a_child_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.feature "Matchmaker sees available Foster Parents for a Child without a Placement and can place them", type: :feature do
+  let(:matchmaker) { create(:matchmaker) }
+
+  let!(:available_foster_parents) { create_list(:foster_parent, 2) }
+  let!(:unavailable_foster_parent) { create(:placement).foster_parent }
+
+  background do
+    sign_in(matchmaker.user)
+
+    visit(shortlist_path(child.id))
+  end
+
+  context "When the Child is not placed and there are available Foster Parents" do
+    let(:child) { create(:child) }
+
+    scenario "Matchmaker looks at Shortlist for a Child which is not currently placed and sees available Foster Parents" do
+      expect(page).to have_content("Foster families")
+      expect(page).to have_content(child.full_name)
+      expect(page).to have_content("2 available families found:")
+
+      available_foster_parents.each do |fp|
+        expect(page).to have_content(fp.full_name)
+      end
+    end
+
+    xscenario "Matchmaker selects an available Foster Parent from the Shortlist and creates a Placement" do
+      within("#foster_parent_#{available_foster_parents.second.id}") do
+        click_on "Place"
+      end
+    end
+  end
+
+  context "When the Child is not placed but there are no available Foster Parents" do
+    let!(:available_foster_parents) { [] }
+    let(:child) { create(:child) }
+
+    scenario "Matchmaker sees that there are no available Foster Parents" do
+      expect(page).to have_content("Foster families")
+      expect(page).to have_content("There are currently no available foster families.")
+    end
+  end
+
+  context "When the Child is already placed" do
+    let(:child) do
+      create(:child).tap do |c|
+        create(:placement, child: c)
+      end
+    end
+
+    scenario "Matchmaker tries to look at a Shortlist for a Child that is already placed and sees a notification" do
+      expect(page).to have_content("Foster families")
+      expect(page).to have_content("#{child.full_name} is currently placed.")
+    end
+  end
+end

--- a/spec/features/short_listing/place_a_child_spec.rb
+++ b/spec/features/short_listing/place_a_child_spec.rb
@@ -25,10 +25,13 @@ RSpec.feature "Matchmaker sees available Foster Parents for a Child without a Pl
       end
     end
 
-    xscenario "Matchmaker selects an available Foster Parent from the Shortlist and creates a Placement" do
+    scenario "Matchmaker selects an available Foster Parent from the Shortlist and creates a Placement" do
       within("#foster_parent_#{available_foster_parents.second.id}") do
         click_on "Place"
       end
+
+      expect(page).to have_content("Placement created")
+      expect(page).to have_content(child.full_name)
     end
   end
 

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -1,9 +1,19 @@
 require "rails_helper"
 
 RSpec.describe Child, type: :model do
+  subject(:model) { build(:child) }
+
   it { is_expected.to have_many(:placements).inverse_of(:child) }
   it { is_expected.to have_many(:foster_parents).through(:placements) }
 
   it { is_expected.to validate_presence_of(:first_name) }
   it { is_expected.to validate_presence_of(:last_name) }
+
+  describe "#full_name" do
+    subject(:model) { build(:child, first_name: "FN", middle_name: "MN", last_name: "LN") }
+
+    it "returns all parts of the name separated by spaces" do
+      expect(model.full_name).to eql("FN MN LN")
+    end
+  end
 end

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -6,14 +6,7 @@ RSpec.describe Child, type: :model do
   it { is_expected.to have_many(:placements).inverse_of(:child) }
   it { is_expected.to have_many(:foster_parents).through(:placements) }
 
-  it { is_expected.to validate_presence_of(:first_name) }
-  it { is_expected.to validate_presence_of(:last_name) }
-
-  describe "#full_name" do
-    subject(:model) { build(:child, first_name: "FN", middle_name: "MN", last_name: "LN") }
-
-    it "returns all parts of the name separated by spaces" do
-      expect(model.full_name).to eql("FN MN LN")
-    end
+  it_behaves_like "name identifiable model" do
+    let(:model_class) { described_class }
   end
 end

--- a/spec/models/concerns/name_identifiable_spec.rb
+++ b/spec/models/concerns/name_identifiable_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe NameIdentifiable do
+  class TestModel
+    include ActiveModel::Model
+    include NameIdentifiable
+
+    attr_accessor :first_name, :middle_name, :last_name
+  end
+
+  include_examples "name identifiable model" do
+    let(:model_class) { TestModel }
+  end
+end

--- a/spec/models/foster_parent_spec.rb
+++ b/spec/models/foster_parent_spec.rb
@@ -7,4 +7,12 @@ RSpec.describe FosterParent, type: :model do
 
   it { is_expected.to validate_presence_of(:first_name) }
   it { is_expected.to validate_presence_of(:last_name) }
+
+  describe "#full_name" do
+    subject(:model) { build(:child, first_name: "FN", middle_name: "MN", last_name: "LN") }
+
+    it "returns all parts of the name separated by spaces" do
+      expect(model.full_name).to eql("FN MN LN")
+    end
+  end
 end

--- a/spec/models/foster_parent_spec.rb
+++ b/spec/models/foster_parent_spec.rb
@@ -5,14 +5,7 @@ RSpec.describe FosterParent, type: :model do
   it { is_expected.to have_many(:placements).inverse_of(:foster_parent) }
   it { is_expected.to have_many(:children).through(:placements) }
 
-  it { is_expected.to validate_presence_of(:first_name) }
-  it { is_expected.to validate_presence_of(:last_name) }
-
-  describe "#full_name" do
-    subject(:model) { build(:child, first_name: "FN", middle_name: "MN", last_name: "LN") }
-
-    it "returns all parts of the name separated by spaces" do
-      expect(model.full_name).to eql("FN MN LN")
-    end
+  it_behaves_like "name identifiable model" do
+    let(:model_class) { described_class }
   end
 end

--- a/spec/models/matchmaker_spec.rb
+++ b/spec/models/matchmaker_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Matchmaker, type: :model do
   it { is_expected.to belong_to(:user).required.inverse_of(:matchmaker) }
 
-  it { is_expected.to validate_presence_of(:first_name) }
-  it { is_expected.to validate_presence_of(:last_name) }
+  it_behaves_like "name identifiable model" do
+    let(:model_class) { described_class }
+  end
 end

--- a/spec/models/shortlist_spec.rb
+++ b/spec/models/shortlist_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Shortlist, type: :model do
+  subject(:model) { described_class.new(child: child) }
+
+  let(:child) { build_stubbed(:child) }
+
+  describe "#id" do
+    it "returns the same id as the child object" do
+      expect(model.id).to eql(child.id)
+    end
+  end
+
+  describe "#child" do
+    it "returns the child assigned during initialisation" do
+      expect(model.child).to eql(child)
+    end
+  end
+end

--- a/spec/policies/child_policy_spec.rb
+++ b/spec/policies/child_policy_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ChildPolicy do
+  subject(:policy) { described_class.new(auth_context, record) }
+
+  let(:auth_context) { AuthorisationContext.new(user) }
+  let(:record) { Shortlist.new(child: child) }
+  let(:child) { build_stubbed(:child) }
+
+  context "for matchmaker" do
+    let(:user) { create(:matchmaker).user }
+
+    it { is_expected.to permit_actions(%i[new create]) }
+  end
+
+  context "for other types of users" do
+    let(:user) { FactoryBot.build_stubbed(:user) }
+
+    it { is_expected.to forbid_actions(%i[new create]) }
+  end
+end

--- a/spec/policies/placement_policy_spec.rb
+++ b/spec/policies/placement_policy_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe PlacementPolicy do
+  subject(:policy) { described_class.new(auth_context, record) }
+
+  let(:auth_context) { AuthorisationContext.new(user) }
+  let(:record) { Placement.new }
+
+  context "for matchmaker" do
+    let(:user) { create(:matchmaker).user }
+
+    it { is_expected.to permit_action(:create) }
+  end
+
+  context "for other types of users" do
+    let(:user) { FactoryBot.build_stubbed(:user) }
+
+    it { is_expected.to forbid_action(:create) }
+  end
+end

--- a/spec/policies/shortlist_policy_spec.rb
+++ b/spec/policies/shortlist_policy_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ShortlistPolicy do
+  subject(:policy) { described_class.new(auth_context, record) }
+
+  let(:auth_context) { AuthorisationContext.new(user) }
+  let(:record) { Shortlist.new(child: child) }
+  let(:child) { build_stubbed(:child) }
+
+  context "for matchmaker" do
+    let(:user) { create(:matchmaker).user }
+
+    it { is_expected.to permit_action(:show) }
+  end
+
+  context "for other types of users" do
+    let(:user) { FactoryBot.build_stubbed(:user) }
+
+    it { is_expected.to forbid_action(:show) }
+  end
+end

--- a/spec/support/shared_examples/name_identifiable_model.rb
+++ b/spec/support/shared_examples/name_identifiable_model.rb
@@ -1,0 +1,28 @@
+RSpec.shared_examples "name identifiable model" do
+  describe "validation" do
+    subject { model_class.new }
+
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+  end
+
+  describe "#full_name" do
+    subject { model.full_name }
+
+    context "when middle name is set" do
+      let(:model) { model_class.new(first_name: "Peter", middle_name: "Michael", last_name: "Smith") }
+
+      it "returns first, middle and last names joined" do
+        is_expected.to eql("Peter Michael Smith")
+      end
+    end
+
+    context "when middle name is not set" do
+      let(:model) { model_class.new(first_name: "Peter", last_name: "Smith") }
+
+      it "returns first and last names joined" do
+        is_expected.to eql("Peter Smith")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This adds a very basic skeleton functionality for listing available foster families creating a placement for a child. 
It's a very crude journey, which will be significantly refined.

There should be a confirmation page showing the child's details, but that will require using the multi step form implemented in #61 and will be added later.

### Changes proposed in this pull request

* Add validated form to create a new child with first and last name
* Create new child and redirect to the shortlist page
* Access shortlist page for a child, which lists available foster parents (or displays an appropriate state message)
* Place a child to an available foster parent from the above page

### Guidance to review

The behaviour is as follows, accessible from the dashboard of a matchmaker:

#### 1. Matchmaker's dashboard with call to action

![Screenshot 2020-11-17 at 22 24 45](https://user-images.githubusercontent.com/986720/99458308-359d6100-2924-11eb-9aa2-a811b0b76c17.png)

#### 2. Child creation form 

![Screenshot 2020-11-17 at 22 24 51](https://user-images.githubusercontent.com/986720/99458369-55348980-2924-11eb-91d1-21afb9cf5bdf.png)

#### 3. Child creation form with errors

![Screenshot 2020-11-17 at 22 25 00](https://user-images.githubusercontent.com/986720/99458384-5c5b9780-2924-11eb-89cb-2b7cda442f9d.png)

#### 4. Shortlist of available families after the child has been created

![Screenshot 2020-11-17 at 22 25 42](https://user-images.githubusercontent.com/986720/99458421-68475980-2924-11eb-9e0e-99fb8681b6af.png)

#### 5. Placement confirmation after selecting a foster family

![Screenshot 2020-11-17 at 22 25 55](https://user-images.githubusercontent.com/986720/99458441-71382b00-2924-11eb-993a-1f481148f9d6.png)


