### PR TITLE
Remove placement input

### DIFF
--- a/app/controllers/children_creation/steps_controller.rb
+++ b/app/controllers/children_creation/steps_controller.rb
@@ -9,14 +9,8 @@ module ChildrenCreation
       children_creation_step_path(step)
     end
 
-    helper_method :step_path
-
-    def wizard_store
-      ::Wizard::Store.new session_store
-    end
-
-    def session_store
-      session[:children_creation] ||= {}
+    def wizard_store_key
+      :children_creation
     end
 
     def on_complete(child)

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -37,7 +37,7 @@ module WizardSteps
 private
 
   def wizard
-    @wizard ||= wizard_class.new(wizard_store, params[:id])
+    @wizard ||= wizard_class.new(wizard_store, params[:id], context: wizard_context)
   end
 
   def current_step
@@ -72,6 +72,10 @@ private
 
   def session_store
     session[wizard_store_key] ||= {}
+  end
+
+  def wizard_context
+    {}
   end
 
   def wizard_store_key

--- a/app/controllers/concerns/wizard_steps.rb
+++ b/app/controllers/concerns/wizard_steps.rb
@@ -3,7 +3,7 @@ module WizardSteps
 
   included do
     class_attribute :wizard_class
-    helper_method :wizard, :current_step
+    helper_method :wizard, :current_step, :step_path
   end
 
   def index
@@ -52,6 +52,10 @@ private
     end
   end
 
+  def step_path(step = params[:id])
+    raise(NotImplementedError)
+  end
+
   def step_params
     return {} unless params.key?(step_param_key)
 
@@ -60,6 +64,18 @@ private
 
   def step_param_key
     current_step.class.model_name.param_key
+  end
+
+  def wizard_store
+    ::Wizard::Store.new(session_store)
+  end
+
+  def session_store
+    session[wizard_store_key] ||= {}
+  end
+
+  def wizard_store_key
+    raise(NotImplementedError)
   end
 
   def on_complete(_result)

--- a/app/controllers/diary/steps_controller.rb
+++ b/app/controllers/diary/steps_controller.rb
@@ -13,6 +13,12 @@ module Diary
       :diary
     end
 
+    def wizard_context
+      {
+        "placement_id" => params[:placement_id],
+      }
+    end
+
     def set_page_title
       @page_title = "#{@current_step.title.downcase} step"
     end

--- a/app/controllers/diary/steps_controller.rb
+++ b/app/controllers/diary/steps_controller.rb
@@ -8,14 +8,9 @@ module Diary
     def step_path(step = params[:id])
       placement_diary_step_path(placement_id: params[:placement_id], id: step)
     end
-    helper_method :step_path
 
-    def wizard_store
-      ::Wizard::Store.new session_store
-    end
-
-    def session_store
-      session[:diary] ||= {}
+    def wizard_store_key
+      :diary
     end
 
     def set_page_title

--- a/app/models/diary/steps/select_event.rb
+++ b/app/models/diary/steps/select_event.rb
@@ -1,12 +1,10 @@
 module Diary::Steps
   class SelectEvent < Wizard::Step
     attribute :event, :string
-    attribute :placement_id # avoid typecasting to allow validation to work
 
     EVENT_OPTIONS = { home_life: "Home life", school_life: "School life", sports: "Sports", physical_health: "Physical health", emotional_health: "Emotional health" }.freeze
 
     validates :event, inclusion: { in: EVENT_OPTIONS.values }
-    validates :placement_id, numericality: { only_integer: true }
 
     def reviewable_answers
       {

--- a/app/models/diary/wizard.rb
+++ b/app/models/diary/wizard.rb
@@ -14,7 +14,7 @@ module Diary
 
     def create_diary_entry
       DiaryEntry.create!(
-        placement_id: @store.data["placement_id"],
+        placement_id: @context["placement_id"],
         event: @store.data["event"],
         note: @store.data["entry"],
       )

--- a/app/models/wizard/base.rb
+++ b/app/models/wizard/base.rb
@@ -30,11 +30,11 @@ module Wizard
     delegate :can_proceed?, to: :find_current_step
     attr_reader :current_key
 
-    def initialize(store, current_key)
-      @store = store
-
+    def initialize(store, current_key, context: {})
       raise(UnknownStep) unless step_keys.include?(current_key)
 
+      @store = store
+      @context = context
       @current_key = current_key
     end
 

--- a/app/views/diary/steps/_select_event.html.erb
+++ b/app/views/diary/steps/_select_event.html.erb
@@ -5,5 +5,3 @@
   <%= f.govuk_radio_button :event, options[:sports],  label: { text: t("select_event.event_options.sports") }, link_errors: true %><%= f.govuk_radio_button :event, options[:physical_health],  label: { text: t("select_event.event_options.physical_health") }, link_errors: true %>
   <%= f.govuk_radio_button :event, options[:emotional_health],  label: { text: t("select_event.event_options.emotional_health") }, link_errors: true %>
 <% end %>
-
-<%= f.text_field :placement_id, pattern: "[0-9]*", inputmode: "numeric", readonly: true, hidden: false, value: params[:placement_id] || f.object.placement_id%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   resources :placements, only: :create do
     namespace :diary do
       resources :steps,
-        only: %i[index show update] do
+                only: %i[index show update] do
         collection do
           get :completed
         end

--- a/spec/models/diary_entry/steps/select_event_spec.rb
+++ b/spec/models/diary_entry/steps/select_event_spec.rb
@@ -6,15 +6,10 @@ RSpec.describe Diary::Steps::SelectEvent do
 
   context "attributes" do
     it { is_expected.to respond_to :event }
-    it { is_expected.to respond_to :placement_id }
   end
 
   describe "event_options" do
     it { is_expected.to_not allow_values("random", "", nil).for :event }
     it { is_expected.to allow_values(*Diary::Steps::SelectEvent::EVENT_OPTIONS.values).for :event }
-  end
-
-  describe "placement_id" do
-    it { should validate_numericality_of(:placement_id).only_integer }
   end
 end


### PR DESCRIPTION
### Context

As a temporary solution we have a `placement_id` input field on the first step of the diary entry wizard form. This removes the need.

### Changes proposed in this pull request

* Introduce optional `context` for the `Wizard::Base` 
* Remove the need to collect `placement_id` in the first step and use it from the parameter

### Guidance to review

Running through the journey is sufficient. As per the bellow screenshot, the input field is no longer there: 

![Screenshot 2020-11-19 at 14 20 08](https://user-images.githubusercontent.com/986720/99678123-64c1e880-2a72-11eb-8944-580a08686437.png)


