### PR TITLE
Add date of birth to children

### DIFF
--- a/app/helpers/answer_helper.rb
+++ b/app/helpers/answer_helper.rb
@@ -4,7 +4,7 @@ module AnswerHelper
   def format_answer(answer)
     case answer
     when Date
-      answer = answer.to_formatted_s(:govuk_date)
+      answer = answer.to_formatted_s(:govuk)
     when Time
       answer = answer.in_time_zone.to_formatted_s(:govuk_time)
     end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -3,4 +3,6 @@ class Child < ApplicationRecord
 
   has_many :placements, inverse_of: :child
   has_many :foster_parents, through: :placements
+
+  validates :date_of_birth, presence: true
 end

--- a/app/models/children_creation/steps/personal_details.rb
+++ b/app/models/children_creation/steps/personal_details.rb
@@ -1,14 +1,18 @@
 module ChildrenCreation
   module Steps
     class PersonalDetails < ::Wizard::Step
+      include ActiveRecord::AttributeAssignment
+
       attribute :first_name, :string
       attribute :last_name, :string
+      attribute :date_of_birth, :date
 
-      validates :first_name, :last_name, presence: true
+      validates :first_name, :last_name, :date_of_birth, presence: true
 
       def reviewable_answers
         {
           "name" => "#{first_name} #{last_name}",
+          "date_of_birth" => date_of_birth,
         }
       end
     end

--- a/app/models/children_creation/wizard.rb
+++ b/app/models/children_creation/wizard.rb
@@ -11,6 +11,7 @@ module ChildrenCreation
       Child.create!(
         first_name: @store.data["first_name"],
         last_name: @store.data["last_name"],
+        date_of_birth: @store.data["date_of_birth"],
       )
     end
   end

--- a/app/services/create_users_and_children.rb
+++ b/app/services/create_users_and_children.rb
@@ -19,6 +19,7 @@ class CreateUsersAndChildren
       foster_parent.children << Child.create_or_find_by!(
         first_name: @row["child_first_name"],
         last_name: @row["child_last_name"],
+        date_of_birth: @row["child_date_of_birth"],
       )
     end
   end

--- a/app/views/children_creation/steps/_personal_details.html.erb
+++ b/app/views/children_creation/steps/_personal_details.html.erb
@@ -2,3 +2,4 @@
 
 <%= f.govuk_text_field :first_name %>
 <%= f.govuk_text_field :last_name %>
+<%= f.govuk_date_field :date_of_birth, date_of_birth: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,9 +65,22 @@ en:
         blank: "Enter the first name"
       last_name:
         blank: "Enter the last name"
+      date_of_birth:
+        blank: "Enter the date of birth"
 
   helpers:
     label:
       children_creation_steps_personal_details:
         first_name: "First name"
         last_name: "Last name"
+    legend:
+      children_creation_steps_personal_details:
+        date_of_birth: "Date of birth"
+    hint:
+      children_creation_steps_personal_details:
+        date_of_birth: "For example, 31 3 1980"
+
+  answers:
+    personal_details:
+      name: "Name"
+      date_of_birth: "Date of birth"

--- a/db/migrate/20201119165703_add_date_of_birth_to_children.rb
+++ b/db/migrate/20201119165703_add_date_of_birth_to_children.rb
@@ -1,0 +1,5 @@
+class AddDateOfBirthToChildren < ActiveRecord::Migration[6.0]
+  def change
+    add_column :children, :date_of_birth, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_17_110313) do
+ActiveRecord::Schema.define(version: 2020_11_19_165703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_11_17_110313) do
     t.string "last_name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "date_of_birth"
   end
 
   create_table "diary_entries", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,11 +39,13 @@ children = [
     id: 201,
     first_name: "Fredrick",
     last_name: "Gutmann",
+    date_of_birth: "2010-10-10",
   },
   {
     id: 202,
     first_name: "Yasmin",
     last_name: "Kub",
+    date_of_birth: "2011-11-11",
   },
 ]
 (203..210).each do |id|
@@ -51,6 +53,7 @@ children = [
     id: id,
     first_name: Faker::Name.first_name,
     last_name: Faker::Name.last_name,
+    date_of_birth: Faker::Date.birthday(min_age: 7, max_age: 15),
   }
 end
 
@@ -105,6 +108,7 @@ unless Rails.env.test?
       id: ch[:id],
       first_name: ch[:first_name],
       last_name: ch[:last_name],
+      date_of_birth: ch[:date_of_birth],
     )
   end
 

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :child do
     first_name { "Rosie" }
     last_name { "Child" }
+    date_of_birth { Date.parse("2010-10-10") }
   end
 end

--- a/spec/features/short_listing/create_a_child_spec.rb
+++ b/spec/features/short_listing/create_a_child_spec.rb
@@ -16,6 +16,9 @@ RSpec.feature "Matchmaker creates a new Child", type: :feature do
   scenario "Matchmaker fills in the Child's details correctly, confirms creation and lands on the shortlist page" do
     fill_in "First name", with: child_attributes[:first_name]
     fill_in "Last name", with: child_attributes[:last_name]
+    fill_in "Day", with: child_attributes[:date_of_birth].day
+    fill_in "Month", with: child_attributes[:date_of_birth].month
+    fill_in "Year", with: child_attributes[:date_of_birth].year
     click_on "Continue"
 
     expect(page).to have_content("Check this is the child you want to find a foster family for?")
@@ -32,17 +35,26 @@ RSpec.feature "Matchmaker creates a new Child", type: :feature do
 
     expect(page).to have_content("There is a problem")
     expect(page).to have_content("Enter the first name")
+    expect(page).to have_content("Enter the date of birth")
   end
 
   scenario "Matchmaker fills in the Child's details correctly, decides to change name and lands on the form again" do
     fill_in "First name", with: child_attributes[:first_name]
     fill_in "Last name", with: child_attributes[:last_name]
+    fill_in "Day", with: child_attributes[:date_of_birth].day
+    fill_in "Month", with: child_attributes[:date_of_birth].month
+    fill_in "Year", with: child_attributes[:date_of_birth].year
     click_on "Continue"
 
-    click_on "Change"
+    within find(".govuk-summary-list__row", match: :first) do
+      click_on "Change"
+    end
 
     expect(page).to have_content("Enter a child's details")
     expect(page).to have_field("First name", with: child_attributes[:first_name])
     expect(page).to have_field("Last name", with: child_attributes[:last_name])
+    expect(page).to have_field("Day", with: child_attributes[:date_of_birth].day)
+    expect(page).to have_field("Month", with: child_attributes[:date_of_birth].month)
+    expect(page).to have_field("Year", with: child_attributes[:date_of_birth].year)
   end
 end

--- a/spec/helpers/answer_helper_spec.rb
+++ b/spec/helpers/answer_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AnswerHelper, type: :helper do
 
     it "correctly formats a date" do
       answer = Date.new(2011, 1, 24)
-      expect(helper.format_answer(answer)).to eq("<span>24 01 2011</span>")
+      expect(helper.format_answer(answer)).to eq("<span>24 January 2011</span>")
     end
 
     it "correctly formats a time" do

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Child, type: :model do
   it { is_expected.to have_many(:placements).inverse_of(:child) }
   it { is_expected.to have_many(:foster_parents).through(:placements) }
 
+  it { is_expected.to validate_presence_of(:date_of_birth) }
+
   it_behaves_like "name identifiable model" do
     let(:model_class) { described_class }
   end

--- a/spec/services/create_users_and_children_spec.rb
+++ b/spec/services/create_users_and_children_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CreateUsersAndChildren do
       "email" => "joe@bloggs.com",
       "child_first_name" => "Tom",
       "child_last_name" => "Mulligan",
+      "child_date_of_birth" => "2010-10-10",
     }
   end
   subject { described_class.new(row) }
@@ -23,6 +24,7 @@ RSpec.describe CreateUsersAndChildren do
       expect(Child.count).to eq 1
       expect(Child.first.first_name).to eq(row["child_first_name"])
       expect(Child.first.last_name).to eq(row["child_last_name"])
+      expect(Child.first.date_of_birth).to eq(Date.parse(row["child_date_of_birth"]))
     end
   end
 end


### PR DESCRIPTION
### Context

To extend the identifiable information for a child profile, this PR adds date of birth as one of the key fields.

### Changes proposed in this pull request

* Add date of birth as a required field to `Child`
* Integrate the GDS style field into the creation wizard

### Guidance to review

Testing involves going through the child creation process:

1) Form with the new field

![Screenshot 2020-11-23 at 15 12 56](https://user-images.githubusercontent.com/986720/99978965-8090fb80-2d9e-11eb-966f-407214163d95.png)

2) Validation works on the date of birth as well

![Screenshot 2020-11-23 at 15 12 26](https://user-images.githubusercontent.com/986720/99978974-838bec00-2d9e-11eb-9f0a-44225811e50b.png)

3) The date of birth can be reviewed and changed alongside the name

![Screenshot 2020-11-23 at 15 13 07](https://user-images.githubusercontent.com/986720/99978993-88e93680-2d9e-11eb-890a-050524308c0b.png)
