### PR TITLE
tests passing for shared postcode example

### DIFF
--- a/app/models/placement_need.rb
+++ b/app/models/placement_need.rb
@@ -19,7 +19,6 @@ class PlacementNeed < ApplicationRecord
   validates :placement_date, :criteria, presence: true
   validates :location_radius_miles, numericality: { only_integer: true, greater_than: 0, less_than: 51 }
   validate :date_in_future
-  validate :check_parsed_postcode
   validates :postcode, postcode: true
 
 private
@@ -32,13 +31,5 @@ private
 
   def sanitize_postcode
     self.postcode = UKPostcode.parse(postcode.gsub(" ", "")).presence if postcode
-  end
-
-  def check_parsed_postcode
-    return unless postcode
-
-    unless UKPostcode.parse(postcode).full_valid?
-      errors.add(:postcode, :invalid)
-    end
   end
 end

--- a/app/models/placement_suitability.rb
+++ b/app/models/placement_suitability.rb
@@ -11,8 +11,7 @@ class PlacementSuitability < ApplicationRecord
   validates :address_line_2, length: { maximum: 1024 }
   validates :address_city, presence: true, length: { maximum: 128 }
   validates :address_county, presence: true, length: { maximum: 128 }
-  validate :check_parsed_postcode
-  validates :address_postcode, postcode: true
+  validates :postcode, postcode: true
 
   def placement_types
     PlacementNeed::OPTIONS.map { |pt| send(pt) == true ? pt : nil }.compact
@@ -28,14 +27,6 @@ private
   end
 
   def sanitize_postcode
-    self.address_postcode = UKPostcode.parse(address_postcode.gsub(" ", "")).presence if address_postcode
-  end
-
-  def check_parsed_postcode
-    return unless address_postcode
-
-    unless UKPostcode.parse(address_postcode).full_valid?
-      errors.add(:address_postcode, :invalid)
-    end
+    self.postcode = UKPostcode.parse(postcode.gsub(" ", "")).presence if postcode
   end
 end

--- a/app/models/seed_data.rb
+++ b/app/models/seed_data.rb
@@ -28,7 +28,7 @@ class SeedData
         address_line_1: "49 Horns Ln",
         address_city: "Norwich",
         address_county: "Norfolk",
-        address_postcode: "NR1 3ER",
+        postcode: "NR1 3ER",
       },
       {
         id: 102,
@@ -39,7 +39,7 @@ class SeedData
         address_line_1: "102 Union St",
         address_city: "Norwich",
         address_county: "Norfolk",
-        address_postcode: "NR2 2TG",
+        postcode: "NR2 2TG",
       },
     ]
     (103..110).each do |id|
@@ -56,7 +56,7 @@ class SeedData
         address_line_1: Faker::Address.street_address,
         address_city: "Norwich",
         address_county: "Norfolk",
-        address_postcode: "NR#{id - 100} 1GA",
+        postcode: "NR#{id - 100} 1GA",
       }
     end
 

--- a/app/models/test_seed_data.rb
+++ b/app/models/test_seed_data.rb
@@ -25,7 +25,7 @@ class TestSeedData < SeedData
         address_line_1: "49 Horns Ln",
         address_city: "Norwich",
         address_county: "Norfolk",
-        address_postcode: "NR1 3ER",
+        postcode: "NR1 3ER",
       },
     ]
     @children = [

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,5 +1,15 @@
 class PostcodeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    if value.nil?
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    unless UKPostcode.parse(value).full_valid?
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
     unless PostcodeApi.new(value).postcode_valid?
       record.errors.add(attribute, :invalid)
     end

--- a/db/migrate/20201215095226_change_address_postcode_to_postcode.rb
+++ b/db/migrate/20201215095226_change_address_postcode_to_postcode.rb
@@ -1,0 +1,5 @@
+class ChangeAddressPostcodeToPostcode < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :placement_suitabilities, :address_postcode, :postcode
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_132841) do
+ActiveRecord::Schema.define(version: 2020_12_15_095226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2020_12_10_132841) do
     t.string "address_line_2"
     t.string "address_city"
     t.string "address_county"
-    t.string "address_postcode"
+    t.string "postcode"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["foster_parent_id"], name: "index_placement_suitabilities_on_foster_parent_id"

--- a/spec/factories/placement_suitabilities.rb
+++ b/spec/factories/placement_suitabilities.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     address_line_2 { "Acacia ave" }
     address_city { "Manchester" }
     address_county { "greater Manchester" }
-    address_postcode { "TR1 1UZ" }
+    postcode { "TR1 1UZ" }
     available { true }
     emergency { true }
     foster_parent

--- a/spec/models/placement_need_spec.rb
+++ b/spec/models/placement_need_spec.rb
@@ -2,20 +2,18 @@ require "rails_helper"
 
 RSpec.describe PlacementNeed, type: :model do
   include_context "sanitize postcodes", %i[postcode]
-  subject { create(:placement_need) }
 
   it { is_expected.to belong_to(:child).required.inverse_of(:placement_need) }
   it { is_expected.to have_one(:placement).inverse_of(:placement_need) }
   it { is_expected.to have_one(:shortlist).inverse_of(:placement_need) }
 
+  describe "#postcode" do
+    it_behaves_like "valid_postcode"
+  end
+
   describe "#placement_date" do
     it { is_expected.to_not allow_value(nil).for :placement_date }
     it { is_expected.to_not allow_value(Time.zone.yesterday).for :placement_date }
-  end
-
-  describe "#postcode" do
-    it { is_expected.to_not allow_value("", "gibberish", nil).for :postcode }
-    it { is_expected.to allow_value("Eh3 9eH", "TR11uz").for :postcode }
   end
 
   describe "#location_radius_miles" do

--- a/spec/models/placement_suitability_spec.rb
+++ b/spec/models/placement_suitability_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe PlacementSuitability, type: :model do
   include_context "sanitize fields", %i[address_line_1 address_line_2 address_city address_county]
-  include_context "sanitize postcodes", %i[address_postcode]
+  include_context "sanitize postcodes", %i[postcode]
 
   it { is_expected.to belong_to(:foster_parent).required.inverse_of(:placement_suitability) }
 
@@ -26,9 +26,10 @@ RSpec.describe PlacementSuitability, type: :model do
 
     it { is_expected.to_not allow_values("", nil, "a" * 129).for :address_county }
     it { is_expected.to allow_value("Up North").for :address_county }
+  end
 
-    it { is_expected.to_not allow_values("", "gibberish", nil).for :address_postcode }
-    it { is_expected.to allow_values("eh3 9eh", "TR11uz").for :address_postcode }
+  describe "#postcode" do
+    it_behaves_like "valid_postcode"
   end
 
   describe "#placement_types" do

--- a/spec/support/shared_examples/valid_postcode.rb
+++ b/spec/support/shared_examples/valid_postcode.rb
@@ -1,0 +1,22 @@
+RSpec.shared_examples "valid_postcode" do
+  describe "validation" do
+    it { is_expected.to_not allow_value("", "gibberish", nil).for :postcode }
+    it { is_expected.to allow_value("Eh3 9eH", "TR11uz").for :postcode }
+
+    context "when nil value" do
+      it "only calls check_parsed_postcode validation" do
+        subject.postcode = nil
+        expect_any_instance_of(PostcodeApi).to_not receive(:postcode_valid?)
+        subject.valid?
+      end
+    end
+
+    context "when correctly formatted but non existent" do
+      it "calls postcode validator" do
+        subject.postcode = "tr1 1ug"
+        expect_any_instance_of(PostcodeApi).to receive(:postcode_valid?).once
+        subject.valid?
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/valid_postcode.rb
+++ b/spec/support/shared_examples/valid_postcode.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples "valid_postcode" do
     it { is_expected.to allow_value("Eh3 9eH", "TR11uz").for :postcode }
 
     context "when nil value" do
-      it "only calls check_parsed_postcode validation" do
+      it "does not call postcode.io api" do
         subject.postcode = nil
         expect_any_instance_of(PostcodeApi).to_not receive(:postcode_valid?)
         subject.valid?
@@ -12,7 +12,7 @@ RSpec.shared_examples "valid_postcode" do
     end
 
     context "when correctly formatted but non existent" do
-      it "calls postcode validator" do
+      it "calls postcode.io api" do
         subject.postcode = "tr1 1ug"
         expect_any_instance_of(PostcodeApi).to receive(:postcode_valid?).once
         subject.valid?


### PR DESCRIPTION
### Context
we need to avoid calling postcode.io api if the postcode is not in the correct format initially
### Changes proposed in this pull request
1. update postcode_validator to check presence and format before calling api
2. change placement_suitability address_postcode to postcode to ease shared examples

