### PR TITLE
revert to address postcode

### DIFF
--- a/app/models/placement_suitability.rb
+++ b/app/models/placement_suitability.rb
@@ -11,7 +11,7 @@ class PlacementSuitability < ApplicationRecord
   validates :address_line_2, length: { maximum: 1024 }
   validates :address_city, presence: true, length: { maximum: 128 }
   validates :address_county, presence: true, length: { maximum: 128 }
-  validates :postcode, postcode: true
+  validates :address_postcode, postcode: true
 
   def placement_types
     PlacementNeed::OPTIONS.map { |pt| send(pt) == true ? pt : nil }.compact
@@ -27,6 +27,6 @@ private
   end
 
   def sanitize_postcode
-    self.postcode = UKPostcode.parse(postcode.gsub(" ", "")).presence if postcode
+    self.address_postcode = UKPostcode.parse(address_postcode.gsub(" ", "")).presence if address_postcode
   end
 end

--- a/app/models/seed_data.rb
+++ b/app/models/seed_data.rb
@@ -28,7 +28,7 @@ class SeedData
         address_line_1: "49 Horns Ln",
         address_city: "Norwich",
         address_county: "Norfolk",
-        postcode: "NR1 3ER",
+        address_postcode: "NR1 3ER",
       },
       {
         id: 102,
@@ -39,7 +39,7 @@ class SeedData
         address_line_1: "102 Union St",
         address_city: "Norwich",
         address_county: "Norfolk",
-        postcode: "NR2 2TG",
+        address_postcode: "NR2 2TG",
       },
     ]
     (103..110).each do |id|
@@ -56,7 +56,7 @@ class SeedData
         address_line_1: Faker::Address.street_address,
         address_city: "Norwich",
         address_county: "Norfolk",
-        postcode: "NR#{id - 100} 1GA",
+        address_postcode: "NR#{id - 100} 1GA",
       }
     end
 

--- a/app/models/test_seed_data.rb
+++ b/app/models/test_seed_data.rb
@@ -25,7 +25,7 @@ class TestSeedData < SeedData
         address_line_1: "49 Horns Ln",
         address_city: "Norwich",
         address_county: "Norfolk",
-        postcode: "NR1 3ER",
+        address_postcode: "NR1 3ER",
       },
     ]
     @children = [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,7 @@ en:
           attributes:
             base:
               options_blank: "Select an option from the list"
-            postcode:
+            address_postcode:
               invalid: "Enter a valid postcode"
 
   select_events:

--- a/db/migrate/20201215121855_revert_postode_to_address_postcode.rb
+++ b/db/migrate/20201215121855_revert_postode_to_address_postcode.rb
@@ -1,0 +1,5 @@
+class RevertPostodeToAddressPostcode < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :placement_suitabilities, :postcode, :address_postcode
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_15_095226) do
+ActiveRecord::Schema.define(version: 2020_12_15_121855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2020_12_15_095226) do
     t.string "address_line_2"
     t.string "address_city"
     t.string "address_county"
-    t.string "postcode"
+    t.string "address_postcode"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["foster_parent_id"], name: "index_placement_suitabilities_on_foster_parent_id"

--- a/spec/factories/placement_suitabilities.rb
+++ b/spec/factories/placement_suitabilities.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     address_line_2 { "Acacia ave" }
     address_city { "Manchester" }
     address_county { "greater Manchester" }
-    postcode { "TR1 1UZ" }
+    address_postcode { "TR1 1UZ" }
     available { true }
     emergency { true }
     foster_parent

--- a/spec/models/placement_need_spec.rb
+++ b/spec/models/placement_need_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PlacementNeed, type: :model do
   it { is_expected.to have_one(:shortlist).inverse_of(:placement_need) }
 
   describe "#postcode" do
-    it_behaves_like "valid_postcode"
+    it_behaves_like "valid_postcode", :postcode
   end
 
   describe "#placement_date" do

--- a/spec/models/placement_suitability_spec.rb
+++ b/spec/models/placement_suitability_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe PlacementSuitability, type: :model do
   include_context "sanitize fields", %i[address_line_1 address_line_2 address_city address_county]
-  include_context "sanitize postcodes", %i[postcode]
+  include_context "sanitize postcodes", %i[address_postcode]
 
   it { is_expected.to belong_to(:foster_parent).required.inverse_of(:placement_suitability) }
 
@@ -28,8 +28,8 @@ RSpec.describe PlacementSuitability, type: :model do
     it { is_expected.to allow_value("Up North").for :address_county }
   end
 
-  describe "#postcode" do
-    it_behaves_like "valid_postcode"
+  describe "#address_postcode" do
+    it_behaves_like "valid_postcode", :address_postcode
   end
 
   describe "#placement_types" do

--- a/spec/support/shared_examples/valid_postcode.rb
+++ b/spec/support/shared_examples/valid_postcode.rb
@@ -1,11 +1,13 @@
-RSpec.shared_examples "valid_postcode" do
+RSpec.shared_examples "valid_postcode" do |field|
   describe "validation" do
-    it { is_expected.to_not allow_value("", "gibberish", nil).for :postcode }
-    it { is_expected.to allow_value("Eh3 9eH", "TR11uz").for :postcode }
+    setter = "#{field}="
+
+    it { is_expected.to_not allow_value("", "gibberish", nil).for field.to_sym }
+    it { is_expected.to allow_value("Eh3 9eH", "TR11uz").for field.to_sym }
 
     context "when nil value" do
       it "does not call postcode.io api" do
-        subject.postcode = nil
+        subject.send(setter, nil)
         expect_any_instance_of(PostcodeApi).to_not receive(:postcode_valid?)
         subject.valid?
       end
@@ -13,7 +15,7 @@ RSpec.shared_examples "valid_postcode" do
 
     context "when correctly formatted but non existent" do
       it "calls postcode.io api" do
-        subject.postcode = "tr1 1ug"
+        subject.send(setter, "tr1 1ug")
         expect_any_instance_of(PostcodeApi).to receive(:postcode_valid?).once
         subject.valid?
       end


### PR DESCRIPTION
### Context
we need to revert to address_postcode to keep the placement_suitablity attributes consistent
### Changes proposed in this pull request
revert attribute name and adjust valid_postcode shared test example
### Guidance to review

