### PR TITLE
Persist shortlist filter

### DIFF
--- a/app/controllers/placement_needs_controller.rb
+++ b/app/controllers/placement_needs_controller.rb
@@ -15,7 +15,7 @@ class PlacementNeedsController < ApplicationController
     authorize @shortlist
 
     if @placement_need.save && @shortlist.save
-      redirect_to shortlist_path(@shortlist)
+      redirect_to edit_shortlist_path(@shortlist)
     else
       render "new"
     end

--- a/app/controllers/shortlists_controller.rb
+++ b/app/controllers/shortlists_controller.rb
@@ -1,18 +1,19 @@
 class ShortlistsController < ApplicationController
-  helper_method :shortlist, :placement_need, :child
+  helper_method :shortlist, :placement_need, :child, :filter_form
 
   def edit
     authorize shortlist
 
-    placement_types = shortlist.placement_types.split(",")
-    @filter_form = Forms::ShortlistFilter.new(placement_types: placement_types)
-    @available_foster_parents = ShortlistFosterParentQuery.new(placement_types: placement_types).call
+    @available_foster_parents = ShortlistFosterParentQuery.new(placement_types: filter_form.placement_types).call
   end
 
   # This may not be the best solution, but we are using the :update route to persist the Shortlist
   # attributes. It then redirects back to the :edit page to be a refreshable page.
   def update
     authorize shortlist
+
+    filter_form.assign_attributes(filter_params)
+    filter_form.save!
 
     redirect_to action: :edit
   end
@@ -29,6 +30,10 @@ private
 
   def child
     @child ||= placement_need.child
+  end
+
+  def filter_form
+    @filter_form ||= Forms::ShortlistFilter.new(shortlist)
   end
 
   def filter_params

--- a/app/models/forms/shortlist_filter.rb
+++ b/app/models/forms/shortlist_filter.rb
@@ -4,38 +4,5 @@ module Forms
     include ActiveModel::Attributes
 
     attr_accessor :placement_types
-
-    def foster_families
-      FosterParent
-        .includes(:placement_suitability)
-        .yield_self(&method(:placements_part))
-        .yield_self(&method(:placement_suitability_part))
-    end
-
-  private
-
-    def placements_part(relation)
-      relation
-        .left_outer_joins(:placements)
-        .where(placements: { foster_parent_id: nil })
-    end
-
-    def placement_suitability_part(relation)
-      return relation if sanitised_placement_types.empty?
-
-      relation
-        .joins(:placement_suitability)
-        .merge(placement_types_condition)
-    end
-
-    def placement_types_condition
-      sanitised_placement_types.inject(PlacementSuitability.none) do |condition, placement_type|
-        condition.or(PlacementSuitability.where(placement_type => true))
-      end
-    end
-
-    def sanitised_placement_types
-      @sanitised_placement_types ||= placement_types&.select { |pt| PlacementNeed::OPTIONS.include?(pt) } || []
-    end
   end
 end

--- a/app/models/forms/shortlist_filter.rb
+++ b/app/models/forms/shortlist_filter.rb
@@ -4,5 +4,15 @@ module Forms
     include ActiveModel::Attributes
 
     attr_accessor :placement_types
+
+    def initialize(shortlist)
+      @shortlist = shortlist
+
+      @placement_types = @shortlist.placement_types&.split(",") || []
+    end
+
+    def save!
+      @shortlist.update(placement_types: @placement_types.reject(&:blank?).join(","))
+    end
   end
 end

--- a/app/models/seed_data.rb
+++ b/app/models/seed_data.rb
@@ -56,7 +56,7 @@ class SeedData
         address_line_1: Faker::Address.street_address,
         address_city: "Norwich",
         address_county: "Norfolk",
-        address_postcode: "NR#{id - 100} 1GA",
+        address_postcode: "NR1 3ER",
       }
     end
 

--- a/app/models/seed_data.rb
+++ b/app/models/seed_data.rb
@@ -125,10 +125,12 @@ class SeedData
       {
         id: 202,
         placement_need_id: 202,
+        placement_types: "long_term",
       },
       {
         id: 203,
         placement_need_id: 203,
+        placement_types: "long_term",
       },
     ]
 

--- a/app/policies/shortlist_policy.rb
+++ b/app/policies/shortlist_policy.rb
@@ -1,5 +1,9 @@
 class ShortlistPolicy < ApplicationPolicy
-  def show?
+  def edit?
+    create?
+  end
+
+  def update?
     create?
   end
 

--- a/app/queries/shortlist_foster_parent_query.rb
+++ b/app/queries/shortlist_foster_parent_query.rb
@@ -1,0 +1,34 @@
+class ShortlistFosterParentQuery
+  def initialize(placement_types: [])
+    @placement_types = placement_types
+  end
+
+  def call
+    FosterParent
+      .includes(:placement_suitability)
+      .yield_self(&method(:placements_part))
+      .yield_self(&method(:placement_suitability_part))
+  end
+
+private
+
+  def placements_part(relation)
+    relation
+      .left_outer_joins(:placements)
+      .where(placements: { foster_parent_id: nil })
+  end
+
+  def placement_suitability_part(relation)
+    return relation if @placement_types.empty?
+
+    relation
+      .joins(:placement_suitability)
+      .merge(placement_types_condition)
+  end
+
+  def placement_types_condition
+    @placement_types.inject(PlacementSuitability.none) do |condition, placement_type|
+      condition.or(PlacementSuitability.where(placement_type => true))
+    end
+  end
+end

--- a/app/views/dashboards/matchmaker.html.erb
+++ b/app/views/dashboards/matchmaker.html.erb
@@ -18,7 +18,7 @@
     <% if @shortlists.present? %>
       <ul class="govuk-list">
         <% @shortlists.each do |shortlist| %>
-          <li><%= govuk_link_to(shortlist.placement_need.child.full_name, shortlist_path(shortlist)) %></li>
+          <li><%= govuk_link_to(shortlist.placement_need.child.full_name, edit_shortlist_path(shortlist)) %></li>
         <% end %>
       </ul>
     <% else %>

--- a/app/views/shortlists/edit.html.erb
+++ b/app/views/shortlists/edit.html.erb
@@ -26,7 +26,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third" style="border: 1px solid #b1b4b6; padding: 20px; margin-top: 10px;">
-    <%= form_for @filter_form, as: :filter, url: shortlist_path(shortlist), method: :patch do |f| %>
+    <%= form_for filter_form, as: :filter, url: shortlist_path(shortlist), method: :patch do |f| %>
       <%= f.govuk_collection_check_boxes :placement_types,
         PlacementNeed::OPTIONS.map { |pt| OpenStruct.new(id: pt, name: t(pt, scope: "enums.placement_type"))},
         :id,

--- a/app/views/shortlists/edit.html.erb
+++ b/app/views/shortlists/edit.html.erb
@@ -7,17 +7,17 @@
 <div class="govuk-grid-row  govuk-!-margin-bottom-8">
   <div class="govuk-grid-column-one-third">
     <span class="govuk-!-display-block">For</span>
-    <p class="govuk-body-l govuk-!-margin-bottom-0"><%= @child.full_name %></p>
-    <span class="govuk-body-m"><%= @child.age %> years old <%= t(@child.gender, scope: "enums.gender").downcase %></span>
+    <p class="govuk-body-l govuk-!-margin-bottom-0"><%= child.full_name %></p>
+    <span class="govuk-body-m"><%= child.age %> years old <%= t(child.gender, scope: "enums.gender").downcase %></span>
   </div>
 
-  <% if @placement_need %>
+  <% if placement_need %>
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-!-display-block">Placement needs</span>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= t(@placement_need.criteria, scope: "enums.placement_type") %></li>
-      <li><%= @placement_need.location_radius_miles %> miles from <%= @placement_need.postcode %></li>
-      <li>By <%= @placement_need.placement_date.to_formatted_s(:govuk) %></li>
+      <li><%= t(placement_need.criteria, scope: "enums.placement_type") %></li>
+      <li><%= placement_need.location_radius_miles %> miles from <%= placement_need.postcode %></li>
+      <li>By <%= placement_need.placement_date.to_formatted_s(:govuk) %></li>
     </ul>
   </div>
   <% end %>
@@ -26,7 +26,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third" style="border: 1px solid #b1b4b6; padding: 20px; margin-top: 10px;">
-    <%= form_for @filter_form, as: :filter, url: shortlist_path(@child), method: :get do |f| %>
+    <%= form_for @filter_form, as: :filter, url: shortlist_path(shortlist), method: :patch do |f| %>
       <%= f.govuk_collection_check_boxes :placement_types,
         PlacementNeed::OPTIONS.map { |pt| OpenStruct.new(id: pt, name: t(pt, scope: "enums.placement_type"))},
         :id,
@@ -56,7 +56,7 @@
             </p>
           <% end %>
 
-          <%= govuk_button_to("Place", placements_path, params: { placement: { foster_parent_id: foster_parent.id, placement_need_id: @placement_need.id } }) %>
+          <%= govuk_button_to("Place", placements_path, params: { placement: { foster_parent_id: foster_parent.id, placement_need_id: placement_need.id } }) %>
 
           <hr class="govuk-section-break govuk-section-break--visible">
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get "/dashboards/matchmaker", to: "dashboards#matchmaker"
   get "/postcode_api_error", to: "pages#postcode_api_error"
 
-  resources :shortlists, only: :show
+  resources :shortlists, only: %i[edit update]
   resources :children do
     resources :placement_needs, only: %i[new create]
   end

--- a/spec/factories/shortlists.rb
+++ b/spec/factories/shortlists.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :shortlist do
     placement_need
+
+    placement_types { placement_need.criteria }
   end
 end

--- a/spec/features/short_listing/place_a_child_spec.rb
+++ b/spec/features/short_listing/place_a_child_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Matchmaker sees available Foster Parents for a Child without a Pl
   background do
     sign_in(matchmaker.user)
 
-    visit(shortlist_path(shortlist.id))
+    visit(edit_shortlist_path(shortlist.id))
   end
 
   context "When there are available Foster Parents" do

--- a/spec/models/forms/shortlist_filter_spec.rb
+++ b/spec/models/forms/shortlist_filter_spec.rb
@@ -1,5 +1,24 @@
 require "rails_helper"
 
 RSpec.describe Forms::ShortlistFilter do
-  subject(:filter) { described_class.new(params) }
+  subject(:filter) { described_class.new(shortlist) }
+
+  let(:shortlist) { create(:shortlist, placement_types: "respite,remand") }
+
+  describe "#initialize" do
+    it "extracts and assigns placement_types attribute as an array from the Shortlist#placement_types field" do
+      expect(filter.placement_types).to eql(%w[respite remand])
+    end
+  end
+
+  describe "#save!" do
+    before do
+      filter.assign_attributes(placement_types: %w[emergency short_term])
+      filter.save!
+    end
+
+    it "stores the placement_types attribute into the Shortlist#placement_types string field" do
+      expect(shortlist.reload.placement_types).to eql("emergency,short_term")
+    end
+  end
 end

--- a/spec/models/forms/shortlist_filter_spec.rb
+++ b/spec/models/forms/shortlist_filter_spec.rb
@@ -2,31 +2,4 @@ require "rails_helper"
 
 RSpec.describe Forms::ShortlistFilter do
   subject(:filter) { described_class.new(params) }
-
-  describe "#foster_families" do
-    subject(:foster_families) { filter.foster_families }
-
-    let!(:available_short_term_fp) { create(:placement_suitability, short_term: true).foster_parent }
-    let!(:available_emergency) { create(:placement_suitability, emergency: true).foster_parent }
-    let!(:available_remand) { create(:placement_suitability, short_break: true, remand: true).foster_parent }
-    let!(:unavailable_fp) do
-      create(:placement_suitability, remand: true).foster_parent.tap { |fp| create(:placement, foster_parent: fp) }
-    end
-
-    context "when placement_types attributes is set" do
-      let(:params) { { "placement_types" => %w[remand short_term] } }
-
-      it "returns only parents who match any of the placement_types" do
-        is_expected.to contain_exactly(available_remand, available_short_term_fp)
-      end
-    end
-
-    context "when placement_types attribute is empty" do
-      let(:params) { {} }
-
-      it "returns all available foster parents" do
-        is_expected.to contain_exactly(available_short_term_fp, available_emergency, available_remand)
-      end
-    end
-  end
 end

--- a/spec/policies/shortlist_policy_spec.rb
+++ b/spec/policies/shortlist_policy_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe ShortlistPolicy do
   context "for matchmaker" do
     let(:user) { create(:matchmaker).user }
 
-    it { is_expected.to permit_actions(%i[create show]) }
+    it { is_expected.to permit_actions(%i[create edit update]) }
   end
 
   context "for other types of users" do
     let(:user) { FactoryBot.build_stubbed(:user) }
 
-    it { is_expected.to forbid_actions(%i[create show]) }
+    it { is_expected.to forbid_actions(%i[create edit update]) }
   end
 
   describe described_class::Scope do

--- a/spec/queries/shortlist_foster_parent_query_spec.rb
+++ b/spec/queries/shortlist_foster_parent_query_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ShortlistFosterParentQuery do
+  subject(:query) { described_class.new(**params) }
+
+  describe "#call" do
+    subject(:call) { query.call }
+
+    let!(:available_short_term_fp) { create(:placement_suitability, short_term: true).foster_parent }
+    let!(:available_emergency) { create(:placement_suitability, emergency: true).foster_parent }
+    let!(:available_remand) { create(:placement_suitability, short_break: true, remand: true).foster_parent }
+    let!(:unavailable_fp) do
+      create(:placement_suitability, remand: true).foster_parent.tap { |fp| create(:placement, foster_parent: fp) }
+    end
+
+    context "when placement_types attributes is set" do
+      let(:params) { { placement_types: %w[remand short_term] } }
+
+      it "returns only parents who match any of the placement_types" do
+        is_expected.to contain_exactly(available_remand, available_short_term_fp)
+      end
+    end
+
+    context "when placement_types attribute is empty" do
+      let(:params) { {} }
+
+      it "returns all available foster parents" do
+        is_expected.to contain_exactly(available_short_term_fp, available_emergency, available_remand)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Every filter action on the shortlisting page is persisted to the `Shortlist` model so that the Matchmaker can come back to it at any time and continue.

### Changes proposed in this pull request

* Change the shortlisting mechanics from `show` into `edit+update` actions
* Extract the foster parents list into a query object
* Repurpose the filter to extract and store the filter from/to the persisted `Shortlist`

### Guidance to review

After changing the filter criteria, going back to the dashboard and then again to the shortlist, the filter should be persisted exactly as left off. 
